### PR TITLE
Fixes get_facts() for stacks

### DIFF
--- a/.github/workflows/pythopackage.yml
+++ b/.github/workflows/pythopackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/napalm_arubaoss/ArubaOS.py
+++ b/napalm_arubaoss/ArubaOS.py
@@ -544,7 +544,7 @@ class ArubaOSS(NetworkDriver):
             vrf=''
     ):
         """
-        Executes traceroute on the device.
+        Execute traceroute on the device.
 
         :param destination: needed argument
         :param source: not implemented as not available from device

--- a/napalm_arubaoss/ArubaOS.py
+++ b/napalm_arubaoss/ArubaOS.py
@@ -30,7 +30,9 @@ from napalm.base.base import NetworkDriver
 logger = logging.getLogger('arubaoss')
 logger.setLevel(logging.INFO)
 
-stream_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+stream_formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
 
 streamhandler = logging.StreamHandler()
 streamhandler.setFormatter(stream_formatter)
@@ -542,7 +544,7 @@ class ArubaOSS(NetworkDriver):
             vrf=''
     ):
         """
-        Execute traceroute on the device and returns a dictionary with the result.
+        Executes traceroute on the device.
 
         :param destination: needed argument
         :param source: not implemented as not available from device

--- a/napalm_arubaoss/helper/get_facts.py
+++ b/napalm_arubaoss/helper/get_facts.py
@@ -30,7 +30,7 @@ def get_facts():
         rest_out = call.json()
         out['hostname'] = rest_out['name']
         out['os_version'] = rest_out['firmware_version']
-        out['serial_number'] = rest_out['serial_number']
+        out['serial_number'] = rest_out.get('serial_number', '')
         out['model'] = rest_out['product_model']
 
         # get domain name to generate the FQDN
@@ -45,6 +45,12 @@ def get_facts():
     call = connection.get(switch_status_url)
     if call.ok:
         rest_out = call.json()
+        if rest_out.get('switch_type', 'ST_STANDALONE') == 'ST_STACKED':
+            serial_url = connection.config['api_url'] +\
+                'system/status/members/1'
+            call = connection.get(serial_url)
+            if call.ok:
+                out['serial_number'] = call.json().get('serial_number')
         for blade in rest_out['blades']:
             for ports in blade['data_ports']:
                 out['interface_list'].append(ports['port_name'])

--- a/napalm_arubaoss/helper/get_facts.py
+++ b/napalm_arubaoss/helper/get_facts.py
@@ -31,7 +31,7 @@ def get_facts():
         out['hostname'] = rest_out['name']
         out['os_version'] = rest_out['firmware_version']
         out['serial_number'] = rest_out.get('serial_number', '')
-        out['model'] = rest_out['product_model']
+        out['model'] = rest_out.get('product_model', '')
 
         # get domain name to generate the FQDN
         call = connection.get(dns_url)
@@ -51,6 +51,7 @@ def get_facts():
             call = connection.get(serial_url)
             if call.ok:
                 out['serial_number'] = call.json().get('serial_number')
+                out['model'] = call.json().get('product_model')
         for blade in rest_out['blades']:
             for ports in blade['data_ports']:
                 out['interface_list'].append(ports['port_name'])


### PR DESCRIPTION
# get_facts for stacked switches

## Description
Fixes `get_facts()` for stacks to be able to retrieve S/N and model_numbers

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
