### PR TITLE
Connection rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ rest-interface
 rest-interface session-idle-timeout 120 #optional
 ```
 
+### optional_args
+optional_args can be set during initialization like this:
+```Python
+from napalm import get_network_driver
+
+d = get_network_driver("arubaoss")
+
+with d('1.2.3.4', 'username', 'password', optional_args={'ssl_verify': False, "debugging": True}) as aruba:
+   print(aruba.get_config())
+```
+
+The following values can be set in optional_args:
+- ssl_verify: bool/str = defaults to **True** - will be passed to the requests object (description can be found [here](https://docs.python-requests.org/en/latest/_modules/requests/sessions/#Session.request))
+- keepalive: bool = defaults to **False** - sets the underlying TCP connection to either keep the connection or not and is a workaround for an issue with ArubaOS devices 
+  (discussed [here](https://community.arubanetworks.com/community-home/digestviewer/viewthread?MID=28798#bme4aa3703-e476-4880-9cb4-9b208f86b2f4))
+- keep_alive: bool = same as keepalive, just shadows it to be able to use the same keyword as in older Python requests versions
+- debugging: bool = defaults to **False** - sets the level of the logging handler to logging.DEBUG
+- disable_ssl_warnings: bool = defaults to **False** - disables ssl warnings from urllib3
+- api: string = defaults to **v6** - defines the API version
+- ssl: bool = defaults to **True**, sets http or https
+
 ### Saltstack
 To use the driver with Saltstack, you would typically need a proxy minion.
 

--- a/napalm_arubaoss/helper/base.py
+++ b/napalm_arubaoss/helper/base.py
@@ -1,13 +1,13 @@
 """Create the Session."""
 
 
-from requests_futures.sessions import FuturesSession
-from requests.models import Response
-from concurrent.futures import as_completed
-from json import JSONDecodeError
 import base64
 import logging
 
+from json import JSONDecodeError
+
+from requests import Session
+from requests.models import Response
 from napalm.base.exceptions import ConnectAuthError
 
 
@@ -21,7 +21,7 @@ class Connection:
 
     def __init__(self):
         """Initialize the class."""
-        self._apisession = None
+        self._apisession: Session = Session()
 
         self.hostname = ""
         self.username = ""
@@ -62,13 +62,18 @@ class Connection:
 
         url = self.config["api_url"] + "login-sessions"
 
-        self._apisession = FuturesSession()
+        self._apisession = Session()
         self._apisession.verify = optional_args.get("ssl_verify", True)
         self._apisession.headers = {
             "Content-Type": "application/json",
-            # "Connection": "close"
         }
-        self._apisession.keep_alive = optional_args.get("keepalive", True)
+        self._apisession.keep_alive = optional_args.get(
+            "keepalive",
+            optional_args.get(
+                "keep_alive",
+                False
+            )
+        )
 
         params = {"userName": self.username, "password": self.password}
 
@@ -103,7 +108,7 @@ class Connection:
         """
         ret = self._apisession.get(*args, **kwargs)
 
-        return ret.result()
+        return ret
 
     def post(self, *args, **kwargs) -> Response:
         """
@@ -115,7 +120,7 @@ class Connection:
         """
         ret = self._apisession.post(*args, **kwargs)
 
-        return ret.result()
+        return ret
 
     def put(self, *args, **kwargs) -> Response:
         """
@@ -127,7 +132,7 @@ class Connection:
         """
         ret = self._apisession.put(*args, **kwargs)
 
-        return ret.result()
+        return ret
 
     def delete(self, *args, **kwargs) -> Response:
         """
@@ -139,7 +144,7 @@ class Connection:
         """
         ret = self._apisession.delete(*args, **kwargs)
 
-        return ret.result()
+        return ret
 
     def cli(self, commands):
         """
@@ -156,28 +161,24 @@ class Connection:
             self.cli_output["error"] = "Provide a list of commands"
             return self.cli_output
 
-        async_calls = (
+        for command in commands:
             self._apisession.post(
                 url=url,
                 json={"cmd": command},
                 timeout=self.timeout,
-                # bug #4 - random delay while re-using TCP connection - workaround:
-                # always close the TCP connection
-                headers={"Content-Type": "application/json", "Connection": "close"},
                 hooks={
-                    "response": self._callback(output=self.cli_output, command=command)
-                },
+                    "response": self._callback(
+                        output=self.cli_output,
+                        command=command
+                    )
+                }
             )
-            for command in commands
-        )
-
-        [call.result() for call in as_completed(async_calls)]
 
         return self.cli_output
 
     def _callback(self, *args, **kwargs):
         """
-        Return Callback for async calls.
+        Return Callback for request calls.
 
         ArubaOSS.cli uses it.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 napalm>=3.3.0
 netaddr
 requests
-requests-futures
 textfsm>=1.1.0
 urllib3


### PR DESCRIPTION
# One-line summary

> Issue : #13 

## Description
- Python requests has been re-implemented again to avoid sharing the TCP Session as it can cause issues with ArubaOS devices
- compare_config needed a sleep between 2 calls as the device seems to take a little time to process a diff request

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
