### PR TITLE
IPv6 raw address improvement

### DIFF
--- a/napalm_arubaoss/ArubaOS.py
+++ b/napalm_arubaoss/ArubaOS.py
@@ -1,4 +1,5 @@
 """ArubaOS-Switch Napalm driver."""
+import ipaddress
 import logging
 import urllib3
 
@@ -73,6 +74,14 @@ class ArubaOSS(NetworkDriver):
 
         if optional_args.get("disable_ssl_warnings", False):
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+        # check if it is an IPv6
+        try:
+            ipaddress.IPv6Address(hostname)
+            # only reached if we got an IPv6 address
+            hostname = "[{}]".format(hostname)
+        except ValueError as ve:
+            pass
 
         self.hostname = hostname
         self.username = username


### PR DESCRIPTION
# Added IPv6 raw address check and handling for underlying requests library

## Description
When using the napalm plugin with the netbox-napalm-module, the underlying requests-library rejects requests when the hostname is not a resolvable FQDN or hostname, but a raw IPv6 address.
To address this, I introduced a quick check in the ArubaOSS-Class that checks if the hostname is an IPv6 address and encloses it in squared brackets `[ip6]`, so it is handled correctly by the requests-library.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
- improvements

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] CHANGELOG
