### PR TITLE
Workaround for load_replace_candidate

### DIFF
--- a/.github/workflows/pythopackage.yml
+++ b/.github/workflows/pythopackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythopackage.yml
+++ b/.github/workflows/pythopackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/napalm_arubaoss/ArubaOS.py
+++ b/napalm_arubaoss/ArubaOS.py
@@ -1,23 +1,23 @@
 """ArubaOS-Switch Napalm driver."""
 import logging
-import urllib3
 
-from napalm_arubaoss.helper.base import Connection
+from napalm.base.base import NetworkDriver
+
 from napalm_arubaoss.helper import (
     backup_config,
     commit_config,
     compare_config,
     confirm_commit,
-    get_mac_address_table,
-    get_facts,
     get_arp_table,
     get_config,
+    get_facts,
     get_interfaces,
     get_interfaces_ip,
     get_lldp_neighbors,
     get_lldp_neighbors_detail,
-    get_ntp_stats,
+    get_mac_address_table,
     get_ntp_servers,
+    get_ntp_stats,
     get_route_to,
     has_pending_commit,
     is_alive,
@@ -27,8 +27,10 @@ from napalm_arubaoss.helper import (
     rollback,
     traceroute,
 )
+from napalm_arubaoss.helper.base import Connection
 
-from napalm.base.base import NetworkDriver
+import urllib3
+
 
 logger = logging.getLogger("arubaoss")
 logger.setLevel(logging.INFO)

--- a/napalm_arubaoss/helper/__init__.py
+++ b/napalm_arubaoss/helper/__init__.py
@@ -24,9 +24,9 @@ from napalm_arubaoss.helper.rollback import rollback
 from napalm_arubaoss.helper.traceroute import traceroute
 from napalm_arubaoss.helper.utils import (
     backup_config,
-    mac_reformat,
     commit_candidate,
     config_batch,
+    mac_reformat,
     read_candidate,
     str_to_b64,
     transaction_status,

--- a/napalm_arubaoss/helper/base.py
+++ b/napalm_arubaoss/helper/base.py
@@ -3,12 +3,12 @@
 
 import base64
 import logging
-
 from json import JSONDecodeError
+
+from napalm.base.exceptions import ConnectAuthError, NapalmException
 
 from requests import Session
 from requests.models import Response
-from napalm.base.exceptions import ConnectAuthError, NapalmException
 
 
 logger = logging.getLogger("arubaoss.helper.base")

--- a/napalm_arubaoss/helper/commit_config.py
+++ b/napalm_arubaoss/helper/commit_config.py
@@ -4,10 +4,10 @@ import logging
 
 from napalm.base.exceptions import CommitError
 
-from napalm_arubaoss.helper.utils import backup_config, commit_candidate
 from napalm_arubaoss.helper.get_config import get_config
-from napalm_arubaoss.helper.load_replace_candidate import load_replace_candidate
 from napalm_arubaoss.helper.has_pending_commit import has_pending_commit
+from napalm_arubaoss.helper.load_replace_candidate import load_replace_candidate
+from napalm_arubaoss.helper.utils import backup_config, commit_candidate
 
 logger = logging.getLogger("arubaoss.helper.commit_config")
 

--- a/napalm_arubaoss/helper/compare_config.py
+++ b/napalm_arubaoss/helper/compare_config.py
@@ -1,7 +1,6 @@
 """Backups and commit the configuration, and handles commit confirm."""
 
 import logging
-
 from time import sleep
 
 from napalm.base.exceptions import CommandErrorException

--- a/napalm_arubaoss/helper/compare_config.py
+++ b/napalm_arubaoss/helper/compare_config.py
@@ -27,7 +27,7 @@ def compare_config(self):
     diff = self.connection.post(url, json=data)
 
     if not diff.ok:
-        raise CommandErrorException("diff generation failed, raise status")
+        raise CommandErrorException(f"diff generation failed, raise status {diff.text}")
 
     for loop_round in range(1, 6):
         # wait a second to give the device time to process
@@ -49,4 +49,20 @@ def compare_config(self):
                 return ""
             continue
         else:
-            return diff_output.json()
+            diff_object = diff_output.json()
+            out = """
+Differences between running config and REST_Payload_Backup
+
+Configuration delete list:
+
+{delete_list}
+
+Configuration add list:
+
+{add_list}
+""".format(
+                delete_list="\n".join(diff_object.get("diff_remove_list")),
+                add_list="\n".join(diff_object.get("diff_add_list"))
+            )
+
+            return out

--- a/napalm_arubaoss/helper/get_arp_table.py
+++ b/napalm_arubaoss/helper/get_arp_table.py
@@ -1,7 +1,8 @@
 """Backups and commit the configuration, and handles commit confirm."""
 
-from napalm.base.helpers import textfsm_extractor
 import logging
+
+from napalm.base.helpers import textfsm_extractor
 
 from napalm_arubaoss.helper.utils import mac_reformat
 

--- a/napalm_arubaoss/helper/get_interfaces.py
+++ b/napalm_arubaoss/helper/get_interfaces.py
@@ -15,7 +15,7 @@ def get_interfaces(self):
         'is_enabled': False,
         'description': '',
         'last_flapped': -1.0,
-        'speed': 1000,
+        'speed': 1000.0,
         'mtu': -1,
         'mac_address': 'FA:16:3E:57:33:61',
     }
@@ -55,7 +55,7 @@ def get_interfaces(self):
         if i_id not in output.keys():
             output[i_id] = interface_template.copy()
 
-        output[i_id]["speed"] = speed
+        output[i_id]["speed"] = float(speed)
 
     for interface_id, interface_values in output.items():
         resp = self.connection.run_cmd(

--- a/napalm_arubaoss/helper/get_interfaces_ip.py
+++ b/napalm_arubaoss/helper/get_interfaces_ip.py
@@ -1,7 +1,8 @@
 """Get IP interface IP addresses."""
 
-from netaddr import IPNetwork
 import logging
+
+from netaddr import IPNetwork
 
 logger = logging.getLogger("arubaoss.helper.get_interfaces_ip")
 

--- a/napalm_arubaoss/helper/get_route_to.py
+++ b/napalm_arubaoss/helper/get_route_to.py
@@ -1,8 +1,10 @@
 """Get route to destination."""
 
-from napalm.base.helpers import textfsm_extractor
-from netaddr import IPNetwork
 import logging
+
+from napalm.base.helpers import textfsm_extractor
+
+from netaddr import IPNetwork
 
 
 logger = logging.getLogger("arubaoss.helper.get_route_to")

--- a/napalm_arubaoss/helper/is_alive.py
+++ b/napalm_arubaoss/helper/is_alive.py
@@ -1,7 +1,8 @@
 """Check if device connection is alive."""
 
-from napalm.base.exceptions import ConnectionClosedException
 import logging
+
+from napalm.base.exceptions import ConnectionClosedException
 
 logger = logging.getLogger("arubaoss.helper.is_alive")
 

--- a/napalm_arubaoss/helper/load_merge_candidate.py
+++ b/napalm_arubaoss/helper/load_merge_candidate.py
@@ -1,9 +1,10 @@
 """Merge candidate configuration with the running one."""
 
-from napalm.base.exceptions import MergeConfigException
 import logging
 
-from napalm_arubaoss.helper.utils import read_candidate, config_batch, backup_config
+from napalm.base.exceptions import MergeConfigException
+
+from napalm_arubaoss.helper.utils import backup_config, config_batch, read_candidate
 
 logger = logging.getLogger("arubaoss.helper.load_merge_candidate")
 

--- a/napalm_arubaoss/helper/load_replace_candidate.py
+++ b/napalm_arubaoss/helper/load_replace_candidate.py
@@ -2,9 +2,9 @@
 
 import logging
 
-from napalm_arubaoss.helper.utils import str_to_b64, read_candidate
-from napalm_arubaoss.helper.is_alive import is_alive
-from napalm.base.exceptions import ReplaceConfigException, ConnectionClosedException
+from napalm.base.exceptions import ConnectionClosedException, ReplaceConfigException
+
+from napalm_arubaoss.helper.utils import read_candidate, str_to_b64
 
 logger = logging.getLogger("arubaoss.helper.load_replace_candidate")
 

--- a/napalm_arubaoss/helper/load_replace_candidate.py
+++ b/napalm_arubaoss/helper/load_replace_candidate.py
@@ -1,9 +1,9 @@
 """Replace running config with the candidate."""
 
-from napalm.base.exceptions import ReplaceConfigException
 import logging
 
 from napalm_arubaoss.helper.utils import str_to_b64, read_candidate
+from napalm.base.exceptions import ReplaceConfigException
 
 logger = logging.getLogger("arubaoss.helper.load_replace_candidate")
 
@@ -37,3 +37,4 @@ def load_replace_candidate(self, filename=None, config=None):
             raise ReplaceConfigException(
                 f"Load configuration failed - Reason: {load.text}"
             )
+        self.open()

--- a/napalm_arubaoss/helper/load_replace_candidate.py
+++ b/napalm_arubaoss/helper/load_replace_candidate.py
@@ -3,7 +3,8 @@
 import logging
 
 from napalm_arubaoss.helper.utils import str_to_b64, read_candidate
-from napalm.base.exceptions import ReplaceConfigException
+from napalm_arubaoss.helper.is_alive import is_alive
+from napalm.base.exceptions import ReplaceConfigException, ConnectionClosedException
 
 logger = logging.getLogger("arubaoss.helper.load_replace_candidate")
 
@@ -37,4 +38,9 @@ def load_replace_candidate(self, filename=None, config=None):
             raise ReplaceConfigException(
                 f"Load configuration failed - Reason: {load.text}"
             )
-        self.open()
+
+        # workaround for the case where the device closes the HTTP session
+        try:
+            self.is_alive()
+        except ConnectionClosedException:
+            self.open()

--- a/napalm_arubaoss/helper/rollback.py
+++ b/napalm_arubaoss/helper/rollback.py
@@ -2,8 +2,8 @@
 
 import logging
 
-from napalm_arubaoss.helper.utils import commit_candidate
 from napalm_arubaoss.helper.compare_config import compare_config
+from napalm_arubaoss.helper.utils import commit_candidate
 
 logger = logging.getLogger("arubaoss.helper.rollback")
 

--- a/napalm_arubaoss/helper/traceroute.py
+++ b/napalm_arubaoss/helper/traceroute.py
@@ -1,7 +1,7 @@
 """Execute traceroute on the device and returns a dictionary with the result."""
 
-import socket
 import logging
+import socket
 
 logger = logging.getLogger("arubaoss.helper.traceroute")
 

--- a/napalm_arubaoss/helper/utils.py
+++ b/napalm_arubaoss/helper/utils.py
@@ -2,8 +2,9 @@
 
 import base64
 import logging
-from time import sleep
 from itertools import zip_longest
+from time import sleep
+
 from napalm.base.exceptions import CommandTimeoutException, CommitError
 
 logger = logging.getLogger("arubaoss.helper.utils")
@@ -161,7 +162,6 @@ def commit_candidate(self, config):
 
     else:
         raise CommitError(f"{cmd_post.json().get('failure_reason', 'failure during cfg_restore but no failure_reason')}")
-
 
 
 def mac_reformat(mac):

--- a/napalm_arubaoss/helper/utils.py
+++ b/napalm_arubaoss/helper/utils.py
@@ -136,7 +136,6 @@ def transaction_status(self, url):
         raise CommitError(f"Transaction failed: {status}")
 
     while status_call()["result"].get("status", "") == "CRS_IN_PROGRESS" and elapsed < self.connection.timeout:
-        print(status_call())
         elapsed += 1
         sleep(1)
 

--- a/napalm_arubaoss/helper/utils.py
+++ b/napalm_arubaoss/helper/utils.py
@@ -4,7 +4,7 @@ import base64
 import logging
 from time import sleep
 from itertools import zip_longest
-from napalm.base.exceptions import CommandTimeoutException
+from napalm.base.exceptions import CommandTimeoutException, CommitError
 
 logger = logging.getLogger("arubaoss.helper.utils")
 
@@ -109,17 +109,38 @@ def transaction_status(self, url):
     :param url:
     :return:
     """
-    status = "CRS_IN_PROGRESS"
-    elapsed = 0
-    while status == "CRS_IN_PROGRESS" and elapsed < self.connection.timeout:
+    def status_call():
+        status = {
+            "result":
+            {
+                "status": "",
+                "http_status_code": None,
+                "failure_reason": ""
+            }
+        }
         call = self.connection.get(url)
         if call.status_code in range(200, 300):
-            status = call.json()
-            return status
+            status["result"]["status"] = call.json().get("status")
+            status["result"]["failure_reason"] = call.json().get("failure_reason")
+            status["result"]["http_status_code"] = call.status_code
+        if call.status_code not in range(200, 300):
+            status["result"]["http_status_code"] = call.status_code
+        return status
+
+    # status = "CRS_IN_PROGRESS"
+    elapsed = 0
+    status = status_call()
+
+    if status["result"].get("status", "") == "CRS_FAILED":
+        raise CommitError(f"Transaction failed: {status}")
+
+    while status_call()["result"].get("status", "") == "CRS_IN_PROGRESS" and elapsed < self.connection.timeout:
+        print(status_call())
         elapsed += 1
         sleep(1)
-    if elapsed == (int(self.connection.timeout) - 1) and status == "CRS_IN_PROGRESS":
-        raise CommandTimeoutException("Transaction timed out")
+
+    if elapsed == (int(self.connection.timeout) - 1) and status_call()["result"].get("status", "") == "CRS_IN_PROGRESS":
+        raise CommandTimeoutException(f"Transaction timed out: {status_call()}")
 
 
 def commit_candidate(self, config):
@@ -134,10 +155,13 @@ def commit_candidate(self, config):
     data = {"server_type": "ST_FLASH", "file_name": config, "is_oobm": False}
     cmd_post = self.connection.post(url, json=data)
 
-    if not cmd_post.json()["failure_reason"]:
+    if not cmd_post.json().get("failure_reason", True):
         check_url = url + "/status"
+        transaction_status(self=self, url=check_url)
 
-        return transaction_status(self=self, url=check_url)
+    else:
+        raise CommitError(f"{cmd_post.json().get('failure_reason', 'failure during cfg_restore but no failure_reason')}")
+
 
 
 def mac_reformat(mac):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-napalm>=3.3.0
+napalm
 netaddr
 requests
 textfsm>=1.1.0
 urllib3
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: POSIX :: Linux",
     ],
     url="https://github.com/napalm-automation-community/napalm-arubaos-switch/",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="napalm-arubaos-switch",
-    version="0.2.0",
+    version="0.2.1",
     packages=find_packages(),
     author="Guillermo Cotone",
     author_email="15230109+gcotone@users.noreply.github.com",


### PR DESCRIPTION
# One-line summary
This PR introduces a workaround for devices which are ending the session after calling "system/config/payload".

## Description
- introduces a workaround for an ended session after calling "system/config/payload"
- resolves most of the style guideline issues 
- transaction_status function has been improved (detailed information on failure)

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements

## Review
- [ ] Tests
