### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Driver implementation for Aruba OS Switch. Tested in AOS > WC.16.09.0004, some m
     * get_probes_*()                  ❌*
     * get_route_to()                  ✅
     * get_snmp_information()          ❌  - Planned
-    * get_users()                     ❌  - Planned
+    * get_users()                     ❌*
     * has_pending_commit()            ✅
     * is_alive()                      ✅
     * load_merge_candidate()          ✅**


### PR DESCRIPTION
# One-line summary
Updated ReadMe

## Description
get_users is not possible on 2930F or 2930M. updated to show this is not possible on tested models

## Types of Changes
- Documentation / non-code